### PR TITLE
fixed code block <span> not removed issue

### DIFF
--- a/script.js
+++ b/script.js
@@ -92,8 +92,7 @@ function htmlToMarkdown(html) {
     markdown = markdown.replace(/<pre>/g, '```'); // replace pre tags with code blocks
     markdown = markdown.replace(/<\/pre>/g, '\n```\n'); // replace pre tags with code blocks
     markdown = markdown.replace(/<button class="flex ml-auto gap-2">(.*?)<\/button>/g, ''); // Remove copy button SVG
-    markdown = markdown.replace(/<span class="[^"]*">|<\/span>/g, ''); // Remove span tags
-    markdown = markdown.replace(/<span>|<\/span>/g, ''); // Remove span tags with no class
+    markdown = markdown.replace(/<span(?: class="[^"]*")?>|<\/span>/g, ''); // Remove span tags with or without a class
     markdown = markdown.replace(/<p>(.*?)<\/p>/g, '$1\n');
 
     const unorderedRegex = /<ul>(.*?)<\/ul>/gs;

--- a/script.js
+++ b/script.js
@@ -93,6 +93,7 @@ function htmlToMarkdown(html) {
     markdown = markdown.replace(/<\/pre>/g, '\n```\n'); // replace pre tags with code blocks
     markdown = markdown.replace(/<button class="flex ml-auto gap-2">(.*?)<\/button>/g, ''); // Remove copy button SVG
     markdown = markdown.replace(/<span class="[^"]*">|<\/span>/g, ''); // Remove span tags
+    markdown = markdown.replace(/<span>|<\/span>/g, ''); // Remove span tags with no class
     markdown = markdown.replace(/<p>(.*?)<\/p>/g, '$1\n');
 
     const unorderedRegex = /<ul>(.*?)<\/ul>/gs;


### PR DESCRIPTION
When exporting a code block, the language type would be prepended with a `<span>` tag that is missed by the regex in the `htmlToMarkdown(html)` function.

Example: 

The issue would look like this: 
```
```<span>javascript
...

```
This update removes that `<span>` tag.

So now it looks like this:

```
```javascript
...

```