### PR TITLE
fix - <span> appearing before language name in code block

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
     "manifest_version": 3,
     "name": "GPT2Markdown",
-    "version": "1.1.3",
+    "version": "1.1.4",
     "description": "Export your conversations with ChatGPT to Markdown ~ by @EmergingTechGuy on Twitter",
     "icons": {
         "16": "images/GPT2Markdown--16.png",

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
     "manifest_version": 3,
     "name": "GPT2Markdown",
-    "version": "1.1.2",
+    "version": "1.1.3",
     "description": "Export your conversations with ChatGPT to Markdown ~ by @EmergingTechGuy on Twitter",
     "icons": {
         "16": "images/GPT2Markdown--16.png",

--- a/script.js
+++ b/script.js
@@ -92,8 +92,7 @@ function htmlToMarkdown(html) {
     markdown = markdown.replace(/<pre>/g, '```'); // replace pre tags with code blocks
     markdown = markdown.replace(/<\/pre>/g, '\n```\n'); // replace pre tags with code blocks
     markdown = markdown.replace(/<button class="flex ml-auto gap-2">(.*?)<\/button>/g, ''); // Remove copy button SVG
-    markdown = markdown.replace(/<span class="[^"]*">|<\/span>/g, ''); // Remove span tags
-    markdown = markdown.replace(/<span>|<\/span>/g, ''); // Remove span tags with no class
+    markdown = markdown.replace(/<span(?: class="[^"]*")?>|<\/span>/g, ''); // Remove span tags with or without a class
     markdown = markdown.replace(/<p>(.*?)<\/p>/g, '$1\n');
 
     const unorderedRegex = /<ul>(.*?)<\/ul>/gs;

--- a/script.js
+++ b/script.js
@@ -27,8 +27,7 @@ new MutationObserver(() => {
 
 function handleClick() {
     if (document.querySelector(".pr-14.bg-gray-800")?.innerText === undefined) return
-    handleLiveChat()
-
+    
     const e = document.querySelectorAll(".text-base");
     let t = "";
     for (const s of e) {

--- a/script.js
+++ b/script.js
@@ -18,23 +18,12 @@ inputActionNode.appendChild(expoButton)
 expoButton.addEventListener('click', handleClick);
 expoButton.addEventListener('load', () => console.log(document.querySelector(".pr-14.bg-gray-800")?.innerText))
 
-const handleLiveChat = () => {
-    setTimeout(() => {
-        chatText = document.querySelector(".pr-14.bg-gray-800")?.innerText
-        if (chatText) console.log('exist!')
-        console.log('not exist!')
-    }, 500);
-}
-
 new MutationObserver(() => {
     handleStore();
 }).observe(rootEle, {
     childList: true,
     subtree: true
 })
-
-let lastEle = bottom.lastElementChild;
-lastEle.appendChild(footer);
 
 function handleClick() {
     if (document.querySelector(".pr-14.bg-gray-800")?.innerText === undefined) return

--- a/script.js
+++ b/script.js
@@ -93,6 +93,7 @@ function htmlToMarkdown(html) {
     markdown = markdown.replace(/<\/pre>/g, '\n```\n'); // replace pre tags with code blocks
     markdown = markdown.replace(/<button class="flex ml-auto gap-2">(.*?)<\/button>/g, ''); // Remove copy button SVG
     markdown = markdown.replace(/<span class="[^"]*">|<\/span>/g, ''); // Remove span tags
+    markdown = markdown.replace(/<span>|<\/span>/g, ''); // Remove span tags with no class
     markdown = markdown.replace(/<p>(.*?)<\/p>/g, '$1\n');
 
     const unorderedRegex = /<ul>(.*?)<\/ul>/gs;


### PR DESCRIPTION
When exporting a code block, the language type would be prepended with a `<span>` tag that is missed by the regex in the `htmlToMarkdown(html)` function.

Example: 

The issue would look like this: 
```
```<span>javascript
...

```
This update removes that `<span>` tag.

So now it looks like this:

```
```javascript
...

```